### PR TITLE
[Fix/#71] Task 버전 저장 로직 수정

### DIFF
--- a/src/main/java/com/capstone/domain/task/entity/Version.java
+++ b/src/main/java/com/capstone/domain/task/entity/Version.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/capstone/domain/task/util/TaskUtil.java
+++ b/src/main/java/com/capstone/domain/task/util/TaskUtil.java
@@ -7,6 +7,7 @@ import com.capstone.global.util.DateTimeUtil;
 import com.capstone.domain.task.dto.request.TaskRequest;
 import com.capstone.domain.task.entity.Version;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -19,10 +20,26 @@ public class TaskUtil {
 
     public Version createOrGetVersion(TaskRequest taskDto, String fileId) {
         Task task = taskRepository.findById(taskDto.taskId()).orElseThrow();
+
         try {
-            Version version = VersionUtil.getCurrentVersionEntity(task);
-            version.getAttachmentList().add(fileId);
-            return version;
+            Version current = VersionUtil.getCurrentVersionEntity(task);
+            List<String> attachmentList = new ArrayList<>();
+            if (current.getAttachmentList() != null) {
+                attachmentList.addAll(current.getAttachmentList());
+            }
+            if(fileId != null){
+                attachmentList.add(fileId);
+            }
+
+            return Version.builder()
+                    .taskId(taskDto.taskId())
+                    .version(taskDto.version())
+                    .modifiedDateTime(DateTimeUtil.getCurrentFormattedDateTime())
+                    .modifiedBy(taskDto.modifiedBy())
+                    .content(taskDto.content())
+                    .attachmentList(attachmentList)
+                    .build();
+
         } catch (GlobalException e) {
             List<String> attachmentList = new ArrayList<>();
             attachmentList.add(fileId);
@@ -34,7 +51,6 @@ public class TaskUtil {
                     .content(taskDto.content())
                     .attachmentList(attachmentList)
                     .build();
-
         }
     }
 


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 어떤 내용을 담고 있는지 한 줄로 요약해주세요. -->
- 버전 저장 로직 수정.

## ✅ 변경사항
<!-- 주요 변경사항을 bullet point로 간단히 작성해주세요. -->
-  version/save 시 버전이 존재하지 않으면 Version 새로 생성(기존 로직 유지)
-  version/save 시 버전이 존재하면 attachmentList만 이전 버전에서 가져오고 Version 새로 생성 후 저장

---

## 🔍 체크리스트
- [ ] PR 제목은 명확한가요?
- [ ] 관련 이슈가 있다면 연결했나요?
- [ ] 로컬 테스트는 통과했나요?
- [ ] 코드에 불필요한 부분은 없나요?

---

## 📎 관련 이슈
<!-- 예: Closes #123 -->
Closes #71

---

## 💬 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보를 적어주세요. 필요 없다면 생략 가능 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 기존 버전이 있을 때 첨부 파일 목록이 올바르게 복사되고 새로운 파일이 조건부로 추가되도록 개선되었습니다.

* **기타**
  * 내부 객체의 필드 값을 외부에서 수정할 수 있도록 setter 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->