### PR TITLE
[Feat/#73] task/version/save 파일 저장 로직 수정

### DIFF
--- a/src/main/java/com/capstone/docs/FileControllerDocs.java
+++ b/src/main/java/com/capstone/docs/FileControllerDocs.java
@@ -1,5 +1,6 @@
 package com.capstone.docs;
 
+import com.capstone.domain.file.dto.FileResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -37,7 +38,7 @@ public interface FileControllerDocs {
                     )
             )
     })
-    ResponseEntity<com.capstone.global.response.ApiResponse<String>> uploadFile(
+    ResponseEntity<com.capstone.global.response.ApiResponse<FileResponse>> uploadFile(
             @PathVariable("taskId") String taskId,
             @RequestParam("file") MultipartFile file) throws Exception;
 

--- a/src/main/java/com/capstone/docs/TaskControllerDocs.java
+++ b/src/main/java/com/capstone/docs/TaskControllerDocs.java
@@ -234,8 +234,9 @@ public interface TaskControllerDocs {
     })
     ResponseEntity<com.capstone.global.response.ApiResponse<TaskVersionResponse>> postVersion(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                                                               @Valid @RequestBody TaskRequest taskDto,
-                                                                                              @RequestParam(value = "fileId", required = false) String fileId);
-
+                                                                                              @RequestParam(value = "fileId", required = false) String fileId,
+                                                                                              @RequestParam(value = "fileName", required = false) String fileName
+    );
     @Operation(description = "작업 내 버전 목록 반환")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "반환 성공"),

--- a/src/main/java/com/capstone/domain/file/controller/FileController.java
+++ b/src/main/java/com/capstone/domain/file/controller/FileController.java
@@ -1,6 +1,7 @@
 package com.capstone.domain.file.controller;
 
 import com.capstone.docs.FileControllerDocs;
+import com.capstone.domain.file.dto.FileResponse;
 import com.capstone.domain.file.service.FileService;
 import com.capstone.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +23,7 @@ public class FileController implements FileControllerDocs {
 
 
     @PostMapping(value = "/upload/{taskId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<String>> uploadFile(
+    public ResponseEntity<ApiResponse<FileResponse>> uploadFile(
             @PathVariable("taskId") String taskId,
             @RequestParam("file") MultipartFile file) throws Exception {
         return ResponseEntity.ok(ApiResponse.onSuccess(fileService.upload(taskId, file)));

--- a/src/main/java/com/capstone/domain/file/dto/FileResponse.java
+++ b/src/main/java/com/capstone/domain/file/dto/FileResponse.java
@@ -1,0 +1,19 @@
+package com.capstone.domain.file.dto;
+
+
+import lombok.Builder;
+
+@Builder
+public record  FileResponse(
+        String fileId,
+        String fileName
+
+) {
+    public static FileResponse from(String fileId, String fileName){
+
+        return FileResponse.builder()
+                .fileId(fileId)
+                .fileName(fileName)
+                .build();
+    }
+}

--- a/src/main/java/com/capstone/domain/file/service/FileService.java
+++ b/src/main/java/com/capstone/domain/file/service/FileService.java
@@ -2,6 +2,7 @@ package com.capstone.domain.file.service;
 
 import com.capstone.domain.file.common.FileMessages;
 import com.capstone.domain.file.common.FileTypes;
+import com.capstone.domain.file.dto.FileResponse;
 import com.capstone.domain.file.exception.InvalidFileException;
 import com.capstone.domain.task.entity.Task;
 import com.capstone.domain.task.entity.Version;
@@ -39,13 +40,7 @@ public class FileService {
     private final GridFsTemplate gridFsTemplate;
     private final TaskRepository taskRepository;
 
-    public String upload(String taskId, MultipartFile file) throws IOException {
-        // Task 전체를 기준으로 가져옴
-        Task task = taskRepository.findById(taskId)
-                .orElseThrow(() -> new GlobalException(ErrorStatus.TASK_NOT_FOUND));
-
-        // 현재 버전에 해당하는 Version 객체를 versionHistory 안에서 직접 가져옴
-        Version targetVersion = VersionUtil.getCurrentVersionEntity(task);
+    public FileResponse upload(String taskId, MultipartFile file) throws IOException {
 
         if (!FileTypes.SUPPORTED_TYPES(file.getContentType())) {
             throw new GlobalException(ErrorStatus.FILE_NOT_SUPPORTED);
@@ -62,13 +57,9 @@ public class FileService {
                 file.getContentType()
         );
 
-        // Version 안에 attachment 추가
-        targetVersion.addAttachment(objectId.toHexString());
 
-        // 전체 Task 저장 (MongoDB는 embedded document만 직접 저장 불가)
-        taskRepository.save(task);
 
-        return objectId.toHexString();
+        return FileResponse.from(objectId.toHexString(),file.getOriginalFilename());
     }
 
     public ResponseEntity<Resource> download(String fileId) {

--- a/src/main/java/com/capstone/domain/task/controller/TaskController.java
+++ b/src/main/java/com/capstone/domain/task/controller/TaskController.java
@@ -61,8 +61,11 @@ public class TaskController implements TaskControllerDocs {
     @PreAuthorize("@projectAuthorityEvaluator.hasTaskPermission(#taskDto.taskId, {'ROLE_MANAGER','ROLE_MEMBER'}, authentication)")
     public ResponseEntity<ApiResponse<TaskVersionResponse>> postVersion(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                             @Valid @RequestBody TaskRequest taskDto,
-                                                            @RequestParam(value = "fileId", required = false) String fileId){
-        return ResponseEntity.ok(ApiResponse.onSuccess(taskService.saveVersion(taskDto, fileId, userDetails)));
+                                                            @RequestParam(value = "fileId", required = false) String fileId,
+                                                                        @RequestParam(value = "fileName", required = false) String fileName
+    )
+    {
+        return ResponseEntity.ok(ApiResponse.onSuccess(taskService.saveVersion(taskDto, fileId, fileName,userDetails)));
     }
 
     @GetMapping("/version/list")

--- a/src/main/java/com/capstone/domain/task/dto/response/AttachmentDto.java
+++ b/src/main/java/com/capstone/domain/task/dto/response/AttachmentDto.java
@@ -1,0 +1,18 @@
+package com.capstone.domain.task.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record AttachmentDto (
+        String fileId,
+        String fileName
+)
+{
+    public static AttachmentDto from(String fileId,String fileName)
+    {
+        return AttachmentDto.builder()
+                .fileId(fileId)
+                .fileName(fileName)
+                .build();
+    }
+}

--- a/src/main/java/com/capstone/domain/task/dto/response/TaskSpecResponse.java
+++ b/src/main/java/com/capstone/domain/task/dto/response/TaskSpecResponse.java
@@ -1,5 +1,6 @@
 package com.capstone.domain.task.dto.response;
 
+import com.capstone.domain.task.entity.Attachment;
 import com.capstone.domain.task.entity.Task;
 import lombok.Builder;
 
@@ -14,10 +15,10 @@ public record  TaskSpecResponse(
         String status,
         String content,
         LocalDate deadline,
-        List<String> attachmentList,
+        List<Attachment> attachmentList,
         List<String> coworkers
 ) {
-    public static TaskSpecResponse from(Task task, List<String> attachments,String content){
+    public static TaskSpecResponse from(Task task, List<Attachment> attachments,String content){
         return TaskSpecResponse.builder()
                 .taskId(task.getId())
                 .title(task.getTitle())

--- a/src/main/java/com/capstone/domain/task/dto/response/TaskSpecResponse.java
+++ b/src/main/java/com/capstone/domain/task/dto/response/TaskSpecResponse.java
@@ -15,10 +15,10 @@ public record  TaskSpecResponse(
         String status,
         String content,
         LocalDate deadline,
-        List<Attachment> attachmentList,
+        List<AttachmentDto> attachmentList,
         List<String> coworkers
 ) {
-    public static TaskSpecResponse from(Task task, List<Attachment> attachments,String content){
+    public static TaskSpecResponse from(Task task, List<AttachmentDto> attachments,String content){
         return TaskSpecResponse.builder()
                 .taskId(task.getId())
                 .title(task.getTitle())

--- a/src/main/java/com/capstone/domain/task/dto/response/TaskVersionResponse.java
+++ b/src/main/java/com/capstone/domain/task/dto/response/TaskVersionResponse.java
@@ -1,5 +1,6 @@
 package com.capstone.domain.task.dto.response;
 
+import com.capstone.domain.task.entity.Attachment;
 import com.capstone.domain.task.entity.Task;
 import com.capstone.domain.task.entity.Version;
 import lombok.Builder;
@@ -14,7 +15,7 @@ public record TaskVersionResponse(
         String modifiedDateTime,
         String modifiedBy,
         String content,
-        List<String> attachmentList,
+        List<Attachment> attachmentList,
         String title,
         LocalDate deadline
 

--- a/src/main/java/com/capstone/domain/task/entity/Attachment.java
+++ b/src/main/java/com/capstone/domain/task/entity/Attachment.java
@@ -1,0 +1,15 @@
+package com.capstone.domain.task.entity;
+
+import com.capstone.global.entity.BaseDocument;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Attachment extends BaseDocument
+{
+    String fileId;
+    String fileName;
+}

--- a/src/main/java/com/capstone/domain/task/entity/Version.java
+++ b/src/main/java/com/capstone/domain/task/entity/Version.java
@@ -17,13 +17,13 @@ public class Version extends BaseDocument{
     private String modifiedDateTime;
     private String modifiedBy;
     private String content;
-    private List<String> attachmentList;
+    private List<Attachment> attachmentList;
 
-    public void addAttachment(String fileId) {
+    public void addAttachment(String fileId,String fileName) {
         if (attachmentList == null) {
             attachmentList = new ArrayList<>();
         }
-        attachmentList.add(fileId);
+        attachmentList.add(new Attachment(fileId, fileName));
     }
 }
 

--- a/src/main/java/com/capstone/domain/task/service/TaskService.java
+++ b/src/main/java/com/capstone/domain/task/service/TaskService.java
@@ -1,9 +1,11 @@
 package com.capstone.domain.task.service;
 
 import com.capstone.domain.task.dto.request.TaskRequest;
+import com.capstone.domain.task.dto.response.AttachmentDto;
 import com.capstone.domain.task.dto.response.TaskResponse;
 import com.capstone.domain.task.dto.response.TaskSpecResponse;
 import com.capstone.domain.task.dto.response.TaskVersionResponse;
+import com.capstone.domain.task.entity.Attachment;
 import com.capstone.domain.task.entity.Task;
 import com.capstone.domain.task.entity.Version;
 import com.capstone.domain.task.message.TaskStatus;
@@ -27,6 +29,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -54,7 +57,15 @@ public class TaskService {
     public TaskSpecResponse loadVersionContent(String taskId) {
         Task task = findTaskByIdOrThrow(taskId);
         Version version = VersionUtil.getCurrentVersionEntity(task);
-        return TaskSpecResponse.from(task, version.getAttachmentList(),version.getContent());
+        List<Attachment>attachments = version.getAttachmentList();
+
+        List<AttachmentDto> attachmentDtos =new ArrayList<>();
+
+        for(Attachment attachment : attachments){
+            attachmentDtos.add(AttachmentDto.from(attachment.getFileId(),attachment.getFileName()));
+        }
+
+        return TaskSpecResponse.from(task, attachmentDtos,version.getContent());
     }
 
     @Transactional
@@ -147,10 +158,18 @@ public class TaskService {
 
         List<Task> taskList = taskRepository.findByProjectId(projectId);
 
+
         return taskList.stream()
                 .map(task -> {
                     Version version = VersionUtil.getCurrentVersionEntity(task);
-                    return TaskSpecResponse.from(task, version.getAttachmentList(),version.getContent());
+                    List<Attachment>attachments = version.getAttachmentList();
+
+                    List<AttachmentDto> attachmentDtos =new ArrayList<>();
+
+                    for(Attachment attachment : attachments){
+                        attachmentDtos.add(AttachmentDto.from(attachment.getFileId(),attachment.getFileName()));
+                    }
+                    return TaskSpecResponse.from(task, attachmentDtos,version.getContent());
                 })
                 .toList();
     }

--- a/src/main/java/com/capstone/domain/task/service/TaskService.java
+++ b/src/main/java/com/capstone/domain/task/service/TaskService.java
@@ -58,8 +58,8 @@ public class TaskService {
     }
 
     @Transactional
-    public TaskVersionResponse saveVersion(TaskRequest taskDto, String fileId, CustomUserDetails customUserDetails){
-        Version version = taskUtil.createOrGetVersion(taskDto, fileId);
+    public TaskVersionResponse saveVersion(TaskRequest taskDto, String fileId,String fileName ,CustomUserDetails customUserDetails){
+        Version version = taskUtil.createOrGetVersion(taskDto, fileId, fileName);
         Task task = findTaskByIdOrThrow(taskDto.taskId());
         TaskChangeDetail beforeChange = TaskChangeDetail.from(task);
 

--- a/src/main/java/com/capstone/domain/task/util/TaskUtil.java
+++ b/src/main/java/com/capstone/domain/task/util/TaskUtil.java
@@ -1,5 +1,7 @@
 package com.capstone.domain.task.util;
 
+import com.capstone.domain.file.dto.FileResponse;
+import com.capstone.domain.task.entity.Attachment;
 import com.capstone.domain.task.entity.Task;
 import com.capstone.domain.task.repository.TaskRepository;
 import com.capstone.global.response.exception.GlobalException;
@@ -18,18 +20,20 @@ import java.util.List;
 public class TaskUtil {
     private final TaskRepository taskRepository;
 
-    public Version createOrGetVersion(TaskRequest taskDto, String fileId) {
+    public Version createOrGetVersion(TaskRequest taskDto,String fileId, String fileName) {
         Task task = taskRepository.findById(taskDto.taskId()).orElseThrow();
 
         try {
             Version current = VersionUtil.getCurrentVersionEntity(task);
-            List<String> attachmentList = new ArrayList<>();
+            List<Attachment> attachmentList = new ArrayList<>();
             if (current.getAttachmentList() != null) {
                 attachmentList.addAll(current.getAttachmentList());
             }
-            if(fileId != null){
-                attachmentList.add(fileId);
+
+            if(fileId!=null && fileName!=null){
+                attachmentList.add(new Attachment(fileId,fileName));
             }
+
 
             return Version.builder()
                     .taskId(taskDto.taskId())
@@ -41,8 +45,11 @@ public class TaskUtil {
                     .build();
 
         } catch (GlobalException e) {
-            List<String> attachmentList = new ArrayList<>();
-            attachmentList.add(fileId);
+            List<Attachment> attachmentList = new ArrayList<>();
+
+            if(fileId!=null && fileName!=null){
+                attachmentList.add(new Attachment(fileId,fileName));
+            }
             return Version.builder()
                     .taskId(taskDto.taskId())
                     .version(taskDto.version())


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 어떤 내용을 담고 있는지 한 줄로 요약해주세요. -->

- file 관련 Attachment 객체 생성 및 task/vsersion/save 단에서 attachmentList에 fileId, fileName 저장

## ✅ 변경사항
<!-- 주요 변경사항을 bullet point로 간단히 작성해주세요. -->
- 기존에는 /file/upload API 내부에서 파일을 DB에 저장한 후, 해당 fileId를 직접 Task의 attachmentList에 추가하는 방식이었고, /task/version/save에서도 동일하게 fileId만 attachmentList에 저장하는 구조라 중복된 로직이 존재했음.
→ 이를 개선하여 /file/upload에서는 파일을 DB에만 저장하고, attachmentList에는 아무 것도 추가하지 않도록 변경함. 대신 /task/version/save에서만 fileId와 fileName을 포함하는 Attachment 객체를 생성해 attachmentList에 저장하도록 로직을 수정함

- Attachment 객체는 각 파일의 fileId와 fileName을 함께 저장하며, attachmentList에는 이 객체들을 담도록 변경


---

## 🔍 체크리스트
- [ ] PR 제목은 명확한가요?
- [ ] 관련 이슈가 있다면 연결했나요?
- [ ] 로컬 테스트는 통과했나요?
- [ ] 코드에 불필요한 부분은 없나요?

---

## 📎 관련 이슈
<!-- 예: Closes #123 -->
Closes #73 

---

## 💬 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보를 적어주세요. 필요 없다면 생략 가능 -->
