### PR TITLE
[Fix/#76] Project 조회 시 유저 email, role 포함 반환

### DIFF
--- a/src/main/java/com/capstone/domain/project/dto/response/ProjectCoworkerDto.java
+++ b/src/main/java/com/capstone/domain/project/dto/response/ProjectCoworkerDto.java
@@ -1,0 +1,18 @@
+package com.capstone.domain.project.dto.response;
+
+import com.capstone.domain.task.dto.response.TaskResponse;
+import com.capstone.domain.task.entity.Task;
+import lombok.Builder;
+
+@Builder
+public record ProjectCoworkerDto(
+        String email,
+        String role
+) {
+    public static ProjectCoworkerDto from(String email,String role) {
+        return ProjectCoworkerDto.builder()
+                .email(email)
+                .role(role)
+                .build();
+    }
+}

--- a/src/main/java/com/capstone/domain/project/dto/response/ProjectResponse.java
+++ b/src/main/java/com/capstone/domain/project/dto/response/ProjectResponse.java
@@ -11,14 +11,14 @@ public record ProjectResponse(
         String projectId,
         String name,
         String description,
-        List<String> coworkers
+        List<ProjectCoworkerDto> coworkers
 ) {
-    public static ProjectResponse from(Project project, List<String> emails){
+    public static ProjectResponse from(Project project, List<ProjectCoworkerDto> coworkers) {
         return ProjectResponse.builder()
                 .projectId(project.getId())
                 .name(project.getProjectName())
                 .description(project.getDescription())
-                .coworkers(emails)
+                .coworkers(coworkers)
                 .build();
     }
 }

--- a/src/main/java/com/capstone/domain/project/service/ProjectService.java
+++ b/src/main/java/com/capstone/domain/project/service/ProjectService.java
@@ -1,6 +1,7 @@
 package com.capstone.domain.project.service;
 
 import com.capstone.domain.project.dto.request.ProjectUpdateRequest;
+import com.capstone.domain.project.dto.response.ProjectCoworkerDto;
 import com.capstone.domain.project.dto.response.ProjectResponse;
 import com.capstone.domain.project.dto.request.ProjectAuthorityRequest;
 import com.capstone.domain.project.dto.request.ProjectSaveRequest;
@@ -26,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.*;
+import java.util.stream.Collectors;
 
 
 @Slf4j
@@ -46,7 +48,15 @@ public class ProjectService {
     }
 
     public ProjectResponse getProjectContent(String projectId){
-        return ProjectResponse.from(findProjectByProjectIdOrThrow(projectId), projectUserRepository.findUserIdByProjectId(projectId));
+        List<ProjectUser> projectUserList= projectUserRepository.findUserIdAndRoleByProjectId(projectId);
+        List<ProjectCoworkerDto> projectCoworkerDtos= projectUserList.stream()
+                .map(coworker->ProjectCoworkerDto.from(
+                        coworker.getUserId(),
+                        coworker.getRole()
+
+                ))
+                .toList();
+        return ProjectResponse.from(findProjectByProjectIdOrThrow(projectId),projectCoworkerDtos);
     }
 
     public Project processRegister(CustomUserDetails customUserDetails, ProjectSaveRequest projectSaveRequest){
@@ -86,8 +96,15 @@ public class ProjectService {
 
         return projects.stream()
                 .map(project -> {
-                    List<String> coworkers = projectUserRepository.findUserIdByProjectId(project.getId());
-                    return ProjectResponse.from(project, coworkers);
+                    List<ProjectUser> projectUserList= projectUserRepository.findUserIdAndRoleByProjectId(project.getId());
+                    List<ProjectCoworkerDto> projectCoworkerDtos= projectUserList.stream()
+                            .map(coworker->ProjectCoworkerDto.from(
+                                    coworker.getUserId(),
+                                    coworker.getRole()
+
+                            ))
+                            .toList();
+                    return ProjectResponse.from(project, projectCoworkerDtos);
                 })
                 .toList();
     }

--- a/src/main/java/com/capstone/domain/user/repository/custom/CustomProjectUserRepository.java
+++ b/src/main/java/com/capstone/domain/user/repository/custom/CustomProjectUserRepository.java
@@ -2,6 +2,7 @@ package com.capstone.domain.user.repository.custom;
 
 import com.capstone.domain.project.dto.query.ProjectUserAuthority;
 import com.capstone.domain.project.entity.Project;
+import com.capstone.domain.user.entity.ProjectUser;
 
 import java.util.List;
 
@@ -9,4 +10,5 @@ public interface CustomProjectUserRepository {
     List<String> findUserIdByProjectId(String projectId);
     List<Project> findProjectsByUserId(String userId);
     List<ProjectUserAuthority> findUserAuthByProjectId(String projectId);
+    List<ProjectUser> findUserIdAndRoleByProjectId(String projectId);
 }

--- a/src/main/java/com/capstone/domain/user/repository/custom/CustomProjectUserRepositoryImpl.java
+++ b/src/main/java/com/capstone/domain/user/repository/custom/CustomProjectUserRepositoryImpl.java
@@ -56,4 +56,11 @@ public class CustomProjectUserRepositoryImpl implements CustomProjectUserReposit
         return mongoTemplate.find(query, ProjectUserAuthority.class, "project_user");
     }
 
+    @Override
+    public List<ProjectUser> findUserIdAndRoleByProjectId(String projectId) {
+        Query query = new Query(Criteria.where("projectId").is(projectId));
+        List<ProjectUser> projectUsers = mongoTemplate.find(query, ProjectUser.class);
+        return projectUsers;
+    }
+
 }


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 어떤 내용을 담고 있는지 한 줄로 요약해주세요. -->
- 기존에는 프로젝트 조회시 해당 프로젝트 유저들의 email만 반환했음 -> 유저 role 까지 포함해 해당 유저가 어떤 권한을 가지고 있는지 확인 간으

## ✅ 변경사항
<!-- 주요 변경사항을 bullet point로 간단히 작성해주세요. -->
- ProjectCoworkerDto를 생성해 email, role 포함함
- project/load 혹은 project/list 시에 List<String> coworkers 반환에서 List<ProjectCoworkerDto> coworkers로 변경
-

---

## 🔍 체크리스트
- [ ] PR 제목은 명확한가요?
- [ ] 관련 이슈가 있다면 연결했나요?
- [ ] 로컬 테스트는 통과했나요?
- [ ] 코드에 불필요한 부분은 없나요?

---

## 📎 관련 이슈
<!-- 예: Closes #123 -->
Closes #76 

---

## 💬 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보를 적어주세요. 필요 없다면 생략 가능 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 프로젝트 협업자 정보를 이메일과 역할로 제공하는 기능이 추가되었습니다.

* **기능 개선**
  * 프로젝트 상세 및 목록 조회 시 협업자 정보가 기존 이메일 리스트에서 이메일과 역할 정보로 확장되었습니다.  
  * 협업자 정보를 보다 상세하게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->