### PR TITLE
[fix] 프로젝트에 사용자 초대 시 중복 초대 방지

### DIFF
--- a/src/main/java/com/capstone/domain/AI/service/AIService.java
+++ b/src/main/java/com/capstone/domain/AI/service/AIService.java
@@ -19,6 +19,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static com.capstone.domain.AI.message.AIMessages.AI_LIMIT_EXCEEDED;
@@ -60,12 +61,12 @@ public class AIService
 
     public void checkUserMembership(String email)
     {
-        User user = userRepository.findUserByEmail(email);
-        if(user==null)
+        Optional<User> user = userRepository.findUserByEmail(email);
+        if(user.isEmpty())
         {
             throw new UserNotFoundException(USER_NOT_FOUND);
         }
-        if(user.getMembership().equals(MembershipType.FREE_USER))
+        if(user.get().getMembership().equals(MembershipType.FREE_USER))
         {
             if (isUsageLimitExceeded(email)) {
                 throw new AIException(AI_LIMIT_EXCEEDED);

--- a/src/main/java/com/capstone/domain/mail/service/ProjectInviteMailService.java
+++ b/src/main/java/com/capstone/domain/mail/service/ProjectInviteMailService.java
@@ -3,6 +3,8 @@ package com.capstone.domain.mail.service;
 import com.capstone.domain.project.entity.Project;
 import com.capstone.domain.user.entity.PendingUser;
 import com.capstone.domain.user.entity.User;
+import com.capstone.domain.user.exception.UserNotFoundException;
+import com.capstone.domain.user.message.UserMessages;
 import com.capstone.domain.user.repository.PendingUserRepository;
 import com.capstone.domain.user.repository.UserRepository;
 import jakarta.mail.MessagingException;
@@ -15,6 +17,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -35,16 +38,22 @@ public class ProjectInviteMailService {
 
         UUID userCredentialCode = UUID.randomUUID();
 
-        User user = userRepository.findUserByEmail(invitee);
+        Optional<User> user = userRepository.findUserByEmail(invitee);
 
-        PendingUser pendingUser = PendingUser.builder()
-                .projectId(projectId)
-                .userId(user.getId())
-                .credentialCode(userCredentialCode.toString())
-                .email(invitee)
-                .build();
+        if(user.isPresent()){
+            User userExist = user.get();
+            PendingUser pendingUser = PendingUser.builder()
+                    .projectId(projectId)
+                    .userId(userExist.getId())
+                    .credentialCode(userCredentialCode.toString())
+                    .email(invitee)
+                    .build();
 
-        pendingUserRepository.save(pendingUser);
+            pendingUserRepository.save(pendingUser);
+        } else {
+            throw new UserNotFoundException(UserMessages.USER_NOT_FOUND);
+        }
+
 
 
 

--- a/src/main/java/com/capstone/domain/mypage/service/MypageService.java
+++ b/src/main/java/com/capstone/domain/mypage/service/MypageService.java
@@ -123,7 +123,7 @@ public class MypageService {
         userRepository.save(userExists);
 
         //프로젝트 및 작업에 저장된 이메일 변경
-        List<Project> projectList=getUserProject(user.orElse(null));
+        List<Project> projectList=getUserProject(userExists);
         log.info("projectList {}",projectList.get(0).getProjectName());
         for(Project project:projectList)
         {

--- a/src/main/java/com/capstone/domain/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/capstone/domain/oauth2/service/CustomOAuth2UserService.java
@@ -14,6 +14,8 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import java.util.Optional;
+
 @RequiredArgsConstructor
 @Service
 @Slf4j
@@ -58,10 +60,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             throw new OAuth2AuthenticationProcessingException("Email not found from OAuth2 provider");
         }
 
-        User existingUser = userRepository.findUserByEmail(oAuth2UserInfo.getEmail());
+        Optional<User> existingUser = userRepository.findUserByEmail(oAuth2UserInfo.getEmail());
         log.info("user", existingUser);
 
-        if (existingUser == null){
+        if (existingUser.isEmpty()){
             User user = User.builder()
                     .email(oAuth2UserInfo.getEmail())
                     .name(oAuth2UserInfo.getName())

--- a/src/main/java/com/capstone/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/capstone/domain/payment/service/PaymentService.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static com.capstone.domain.user.message.UserMessages.USER_NOT_FOUND;
 
@@ -31,16 +32,17 @@ public class PaymentService {
     public PaymentEntity processPayment(CustomUserDetails userDetails, String impUid)
     {
         String email =userDetails.getEmail();
-        User user=userRepository.findUserByEmail(email);
-        if(user == null)
+        Optional<User> user = userRepository.findUserByEmail(email);
+        if(user.isEmpty())
         {
             throw new UserNotFoundException(USER_NOT_FOUND);
         }
         log.info("email={}",email);
 
+        User userExist = user.get();
         //유저 멤버쉽 프리미엄으로 변경
-        user.setMembership(MembershipType.PREMIUM_USER);
-        userRepository.save(user);
+        userExist.setMembership(MembershipType.PREMIUM_USER);
+        userRepository.save(userExist);
 
         //결제 엔티티 생성ㅇ
         PaymentEntity paymentEntity = PaymentEntity.builder()

--- a/src/main/java/com/capstone/domain/project/service/ProjectService.java
+++ b/src/main/java/com/capstone/domain/project/service/ProjectService.java
@@ -53,16 +53,11 @@ public class ProjectService {
         List<ProjectCoworkerDto> projectCoworkerDtos= projectUserList.stream()
                 .map(coworker->
                         {
-                            Optional<User> user = userService.findUserByEmailOrThrow(coworker.getUserId());
-                            if(user.isPresent()){
-                                return ProjectCoworkerDto.from(
-                                        coworker.getUserId(),
-                                        coworker.getRole(),
-                                        user.get().getName());
-                            }
-                            else {
-                                throw new UserNotFoundException(UserMessages.USER_NOT_FOUND);
-                            }
+                            User user = userService.findUserByEmailOrThrow(coworker.getUserId());
+                            return ProjectCoworkerDto.from(
+                                    coworker.getUserId(),
+                                    coworker.getRole(),
+                                    user.getName());
                         }
                 )
                 .toList();
@@ -116,16 +111,11 @@ public class ProjectService {
                     List<ProjectUser> projectUserList= projectUserRepository.findUserIdAndRoleByProjectId(project.getId());
                     List<ProjectCoworkerDto> projectCoworkerDtos= projectUserList.stream()
                             .map(coworker->{
-                                Optional<User> user = userService.findUserByEmailOrThrow(coworker.getUserId());
-                                if(user.isPresent()){
-                                    User userExists = user.get();
-                                    return ProjectCoworkerDto.from(
-                                            coworker.getUserId(),
-                                            coworker.getRole(),
-                                            userExists.getName());
-                                } else {
-                                    throw new UserNotFoundException(UserMessages.USER_NOT_FOUND);
-                                }
+                                User user = userService.findUserByEmailOrThrow(coworker.getUserId());
+                                return ProjectCoworkerDto.from(
+                                        coworker.getUserId(),
+                                        coworker.getRole(),
+                                        user.getName());
 
                             })
                             .toList();

--- a/src/main/java/com/capstone/domain/user/message/UserMessages.java
+++ b/src/main/java/com/capstone/domain/user/message/UserMessages.java
@@ -3,4 +3,6 @@ package com.capstone.domain.user.message;
 public class UserMessages {
     public static final String USER_NOT_FOUND = "해당 유저를 찾을 수 없습니다.";
     public static final String USER_FOUND = "해당 유저가 이미 존재합니다.";
+    public static final String PROJECT_USER_EXISTS = "해당 유저가 이미 프로젝트에 소속되어 있습니다.";
+    public static final String PENDING_USER_EXISTS = "해당 유저는 현재 초대 수락 대기 상태입니다.";
 }

--- a/src/main/java/com/capstone/domain/user/repository/custom/CustomPendingUserRepository.java
+++ b/src/main/java/com/capstone/domain/user/repository/custom/CustomPendingUserRepository.java
@@ -2,6 +2,9 @@ package com.capstone.domain.user.repository.custom;
 
 import com.capstone.domain.user.entity.PendingUser;
 
+import java.util.Optional;
+
 public interface CustomPendingUserRepository {
     PendingUser findByCredentialCode(String credentialCode);
+    Optional<PendingUser> findByProjectAndUser(String projectId, String userId);
 }

--- a/src/main/java/com/capstone/domain/user/repository/custom/CustomPendingUserRepositoryImpl.java
+++ b/src/main/java/com/capstone/domain/user/repository/custom/CustomPendingUserRepositoryImpl.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Repository;
 
 import org.springframework.data.mongodb.core.query.Query;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class CustomPendingUserRepositoryImpl implements CustomPendingUserRepository {
@@ -20,5 +22,13 @@ public class CustomPendingUserRepositoryImpl implements CustomPendingUserReposit
         Query query = new Query().addCriteria(Criteria.where("credentialCode").is(credentialCode));
 
         return mongoTemplate.findOne(query, PendingUser.class);
+    }
+
+    @Override
+    public Optional<PendingUser> findByProjectAndUser(String projectId, String userId) {
+        Query query = new Query().addCriteria(Criteria.where("projectId").is(projectId)
+                .and("userId").is(userId));
+
+        return Optional.ofNullable(mongoTemplate.findOne(query, PendingUser.class));
     }
 }

--- a/src/main/java/com/capstone/domain/user/repository/custom/CustomProjectUserRepository.java
+++ b/src/main/java/com/capstone/domain/user/repository/custom/CustomProjectUserRepository.java
@@ -5,9 +5,11 @@ import com.capstone.domain.project.entity.Project;
 import com.capstone.domain.user.entity.ProjectUser;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CustomProjectUserRepository {
     List<String> findUserIdByProjectId(String projectId);
     List<Project> findProjectsByUserId(String userId);
     List<ProjectUser> findUserIdAndRoleByProjectId(String projectId);
+    Optional<ProjectUser> findByProjectAndUser(String projectId, String userId);
 }

--- a/src/main/java/com/capstone/domain/user/repository/custom/CustomProjectUserRepositoryImpl.java
+++ b/src/main/java/com/capstone/domain/user/repository/custom/CustomProjectUserRepositoryImpl.java
@@ -11,6 +11,7 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -50,6 +51,14 @@ public class CustomProjectUserRepositoryImpl implements CustomProjectUserReposit
         Query query = new Query(Criteria.where("projectId").is(projectId));
         List<ProjectUser> projectUsers = mongoTemplate.find(query, ProjectUser.class);
         return projectUsers;
+    }
+
+    @Override
+    public Optional<ProjectUser> findByProjectAndUser(String projectId, String userId) {
+        Query query = new Query().addCriteria(Criteria.where("projectId").is(projectId)
+                .and("userId").is(userId));
+
+        return Optional.ofNullable(mongoTemplate.findOne(query, ProjectUser.class));
     }
 
 }

--- a/src/main/java/com/capstone/domain/user/repository/custom/CustomUserRepository.java
+++ b/src/main/java/com/capstone/domain/user/repository/custom/CustomUserRepository.java
@@ -3,8 +3,9 @@ package com.capstone.domain.user.repository.custom;
 import com.capstone.domain.user.entity.User;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CustomUserRepository {
-    User findUserByEmail(String email);
+    Optional<User> findUserByEmail(String email);
     List<String> findUserProjectByEmail(String email);
 }

--- a/src/main/java/com/capstone/domain/user/repository/custom/CustomUserRepositoryImpl.java
+++ b/src/main/java/com/capstone/domain/user/repository/custom/CustomUserRepositoryImpl.java
@@ -8,15 +8,16 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
 public class CustomUserRepositoryImpl implements CustomUserRepository{
     private final MongoTemplate mongoTemplate;
     @Override
-    public User findUserByEmail(String email) {
+    public Optional<User> findUserByEmail(String email) {
         Query query = new Query().addCriteria(Criteria.where("email").is(email));
-        return mongoTemplate.findOne(query, User.class);
+        return Optional.ofNullable(mongoTemplate.findOne(query, User.class));
     }
 
     @Override

--- a/src/main/java/com/capstone/domain/user/service/ProjectUserService.java
+++ b/src/main/java/com/capstone/domain/user/service/ProjectUserService.java
@@ -6,8 +6,12 @@ import com.capstone.domain.project.entity.Project;
 import com.capstone.domain.project.repository.ProjectRepository;
 import com.capstone.domain.user.entity.PendingUser;
 import com.capstone.domain.user.entity.ProjectUser;
+import com.capstone.domain.user.entity.User;
+import com.capstone.domain.user.exception.UserFoundException;
+import com.capstone.domain.user.message.UserMessages;
 import com.capstone.domain.user.repository.PendingUserRepository;
 import com.capstone.domain.user.repository.ProjectUserRepository;
+import com.capstone.domain.user.repository.UserRepository;
 import com.capstone.global.kafka.dto.ProjectAuthPayload;
 import com.capstone.global.kafka.dto.ProjectInvitePayload;
 import com.capstone.global.kafka.service.KafkaProducerService;
@@ -21,20 +25,36 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalTime;
+import java.util.Optional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ProjectUserService {
     private final ProjectUserRepository projectUserRepository;
-    private final KafkaProducerService kafkaProducerService;
     private final ProjectRepository projectRepository;
     private final PendingUserRepository pendingUserRepository;
+    private final UserRepository userRepository;
+
+    private final KafkaProducerService kafkaProducerService;
 
     @Transactional
     public void processInvite(CustomUserDetails customUserDetails, String projectId, ProjectInviteRequest projectInviteRequest) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(()-> new GlobalException(ErrorStatus.PROJECT_NOT_FOUND));
+
+        User user = userRepository.findUserByEmail(projectInviteRequest.email());
+        String userId = user.getId();
+
+        Optional<PendingUser> pendingUserExists = pendingUserRepository.findByProjectAndUser(projectId, userId);
+        if(pendingUserExists.isPresent()){
+            throw new UserFoundException(UserMessages.PENDING_USER_EXISTS);
+        }
+
+        Optional<ProjectUser> projectUserExists = projectUserRepository.findByProjectIdAndUserId(projectId, userId);
+        if(projectUserExists.isPresent()){
+            throw new UserFoundException(UserMessages.PROJECT_USER_EXISTS);
+        }
 
         kafkaProducerService.sendEvent(KafkaEventTopic.PROJECT_INVITED, ProjectInvitePayload.from(project, customUserDetails, projectInviteRequest.email()));
     }

--- a/src/main/java/com/capstone/global/jwt/JwtUtil.java
+++ b/src/main/java/com/capstone/global/jwt/JwtUtil.java
@@ -115,7 +115,7 @@ public class JwtUtil {
         }
 
         // DB에서 googleId 기반으로 사용자 찾기
-        Optional<User> userOptional = Optional.ofNullable(userRepository.findUserByEmail(email));
+        Optional<User> userOptional = userRepository.findUserByEmail(email);
         if (userOptional.isEmpty()) {
             throw new UsernameNotFoundException("User not found with googleId: " + email);
         }

--- a/src/main/java/com/capstone/global/jwt/LoginFilter.java
+++ b/src/main/java/com/capstone/global/jwt/LoginFilter.java
@@ -3,6 +3,8 @@ package com.capstone.global.jwt;
 //import com.capstone.domain.auth.exception.SocialLoginException;
 import com.capstone.domain.auth.login.dto.LoginRequest;
 import com.capstone.domain.user.entity.User;
+import com.capstone.domain.user.exception.UserNotFoundException;
+import com.capstone.domain.user.message.UserMessages;
 import com.capstone.domain.user.repository.UserRepository;
 import com.capstone.global.security.CustomUserDetails;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -50,8 +52,12 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
             Optional<User> user = userRepository.findUserByEmail(loginRequest.getEmail());
             log.info("");
 
-            if (user.get().getSocial() != null){
-                throw new RuntimeException(user.get().getSocial() + "계정으로 가입된 회원입니다.");
+            if(user.isPresent()){
+                if (user.get().getSocial() != null){
+                    throw new RuntimeException(user.get().getSocial() + "계정으로 가입된 회원입니다.");
+                }
+            } else {
+                throw new UserNotFoundException(UserMessages.USER_NOT_FOUND);
             }
 
             UsernamePasswordAuthenticationToken authToken =

--- a/src/main/java/com/capstone/global/jwt/LoginFilter.java
+++ b/src/main/java/com/capstone/global/jwt/LoginFilter.java
@@ -22,6 +22,7 @@ import org.springframework.util.StreamUtils;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 
 @Slf4j
 public class LoginFilter extends UsernamePasswordAuthenticationFilter {
@@ -46,11 +47,11 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
             String messageBody = StreamUtils.copyToString(request.getInputStream(), StandardCharsets.UTF_8);
             LoginRequest loginRequest = new ObjectMapper().readValue(messageBody, LoginRequest.class);
 
-            User user = userRepository.findUserByEmail(loginRequest.getEmail());
+            Optional<User> user = userRepository.findUserByEmail(loginRequest.getEmail());
             log.info("");
 
-            if (user.getSocial() != null){
-                throw new RuntimeException(user.getSocial() + "계정으로 가입된 회원입니다.");
+            if (user.get().getSocial() != null){
+                throw new RuntimeException(user.get().getSocial() + "계정으로 가입된 회원입니다.");
             }
 
             UsernamePasswordAuthenticationToken authToken =

--- a/src/main/java/com/capstone/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/capstone/global/security/CustomUserDetailsService.java
@@ -1,20 +1,16 @@
 package com.capstone.global.security;
 
-import com.capstone.domain.project.entity.Project;
-import com.capstone.domain.task.entity.Task;
 import com.capstone.domain.user.entity.User;
 import com.capstone.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -26,12 +22,12 @@ public class CustomUserDetailsService implements UserDetailsService{
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        User user = userRepository.findUserByEmail(email);
+        Optional<User> user = userRepository.findUserByEmail(email);
 
-        if (user == null) {
+        if (user.isEmpty()) {
             throw new UsernameNotFoundException("User not found with email: " + email);
         }
 
-        return new CustomUserDetails(user);
+        return new CustomUserDetails(user.get());
     }
 }

--- a/src/main/resources/static/oauth2.html
+++ b/src/main/resources/static/oauth2.html
@@ -10,7 +10,7 @@
 <p>Click the button below to log in with your Google account:</p>
 
 <!-- GET 요청으로 Google 로그인 페이지로 이동 -->
-<a href="http://localhost:8080/oauth2/authorization/google?redirect_uri=http://localhost:63342/capstone/capstone.main/static/file.html?_ijt=ge1hj50qma96gntqv8r6ejcp9f&_ij_reload=RELOAD_ON_SAVE/&mode=login">
+<a href="http://localhost:8080/oauth2/authorization/google?access_type=offline&mode=login&redirect_uri=http://gcpassist.com?&userId=999331911900086413&guildId=1343323552555995290">
   <button type="button" style="padding: 10px 20px; font-size: 16px; cursor: pointer;">
     Login with Google
   </button>


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 어떤 내용을 담고 있는지 한 줄로 요약해주세요. -->
- 프로젝트 초대 시 , pending_user와 project_user에서 선조회 후 둘 다 없으면 초대 진행
---

## ✅ 변경사항
<!-- 주요 변경사항을 bullet point로 간단히 작성해주세요. -->
- CustomPendingUserRepository와 CustomProjectUserRepository에서 사용자 조회 쿼리 추가 
- 둘 중 어느 하나에도 존재하면 예외 발생

---

## 🔍 체크리스트
- [x] PR 제목은 명확한가요?
- [x] 관련 이슈가 있다면 연결했나요?
- [x] 로컬 테스트는 통과했나요?
- [x] 코드에 불필요한 부분은 없나요?

---

## 📎 관련 이슈
<!-- 예: Closes #123 -->
Closes #96 

---

## 💬 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보를 적어주세요. 필요 없다면 생략 가능 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 프로젝트 초대 시, 이미 해당 프로젝트에 소속된 유저 또는 초대 대기 중인 유저에 대해 안내 메시지가 제공됩니다.
  * 프로젝트 및 유저 정보를 기반으로 소속 여부 또는 초대 대기 상태를 정확히 확인할 수 있습니다.
  * OAuth2 로그인 시 오프라인 접근 권한 요청 및 리디렉션 URL이 업데이트되었습니다.

* **버그 수정**
  * 중복 초대 및 소속 유저에 대한 예외 처리가 강화되어, 불필요한 초대 이벤트 발생을 방지합니다.

* **리팩터링**
  * 사용자 조회 시 Optional<User> 사용으로 null 안전성이 향상되었습니다.
  * 사용자 관련 서비스 및 저장소에서 Optional을 활용한 일관된 예외 처리 및 검증 로직이 적용되었습니다.
  * 불필요한 임포트 및 필드가 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->