### PR TITLE
[feat] 초대 수락 후 이동할 페이지 주소 변경 

### DIFF
--- a/.github/workflows/workflow-release.yml
+++ b/.github/workflows/workflow-release.yml
@@ -2,7 +2,7 @@ name: CI / CD
 
 on:
   push:
-    branches: [main]
+    branches: [feat/#152-invite-redirection-url]
 
 jobs:
   CI:

--- a/src/main/java/com/capstone/domain/mail/service/ProjectInviteMailService.java
+++ b/src/main/java/com/capstone/domain/mail/service/ProjectInviteMailService.java
@@ -1,10 +1,10 @@
 package com.capstone.domain.mail.service;
 
-import com.capstone.domain.project.entity.Project;
+import com.capstone.domain.project.entity.InviteCode;
+import com.capstone.domain.project.repository.InviteCodeRepository;
 import com.capstone.domain.user.entity.PendingUser;
 import com.capstone.domain.user.entity.User;
 import com.capstone.domain.user.exception.UserNotFoundException;
-import com.capstone.domain.user.message.UserMessages;
 import com.capstone.domain.user.repository.PendingUserRepository;
 import com.capstone.domain.user.repository.UserRepository;
 import jakarta.mail.MessagingException;
@@ -26,6 +26,7 @@ public class ProjectInviteMailService {
     private final JavaMailSender javaMailSender;
     private final PendingUserRepository pendingUserRepository;
     private final UserRepository userRepository;
+    private final InviteCodeRepository inviteCodeRepository;
     private String ePw;
 
     @Value("${spring.mail.username}")
@@ -41,14 +42,16 @@ public class ProjectInviteMailService {
         Optional<User> user = userRepository.findUserByEmail(invitee);
 
         if(user.isPresent()){
+            InviteCode inviteCode = InviteCode.of(userCredentialCode.toString(), projectId);
+
             User userExist = user.get();
             PendingUser pendingUser = PendingUser.builder()
-                    .projectId(projectId)
                     .userId(userExist.getId())
-                    .credentialCode(userCredentialCode.toString())
+                    .inviteCode(inviteCode)
                     .email(invitee)
                     .build();
 
+            inviteCodeRepository.save(inviteCode);
             pendingUserRepository.save(pendingUser);
         } else {
             throw new UserNotFoundException();
@@ -65,7 +68,7 @@ public class ProjectInviteMailService {
               <strong style="color: #2c3e50;">%s</strong> 님이 당신을 <strong style="color: #3498db;">%s</strong> 프로젝트에 초대했습니다.
             </p>
             <p style="font-size: 15px; color: #666666;">
-              아래 버튼을 눌러 프로젝트에 참여하세요.
+              아래 버튼을 눌러 프로젝트에 참여하세요. 본 초대 메일의 유효 시간은 10분입니다.
             </p>
             <div style="text-align: center; margin: 30px 0;">
               <a href="%s" style="background-color: #3498db; color: #ffffff; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold;">

--- a/src/main/java/com/capstone/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/capstone/domain/project/controller/ProjectController.java
@@ -91,11 +91,8 @@ public class ProjectController implements ProjectControllerDocs {
 
     @GetMapping("/invite/accept")
     public ResponseEntity<Object> acceptInvitation(@RequestParam String credentialCode){
-        projectUserService.insertProjectUser(credentialCode);
-
-        // TODO: 프론트 배포 후 해당 주소로 변경
-        URI redirectUri = URI.create("https://www.naver.com");
-        return ResponseEntity.status(HttpStatus.FOUND).location(redirectUri).build();
+        String redirectUri = projectUserService.processInviteAcceptProjectUser(credentialCode);
+        return ResponseEntity.status(HttpStatus.FOUND).location(URI.create(redirectUri)).build();
     }
 
     @GetMapping("/load")

--- a/src/main/java/com/capstone/domain/project/entity/InviteCode.java
+++ b/src/main/java/com/capstone/domain/project/entity/InviteCode.java
@@ -23,12 +23,13 @@ public class InviteCode extends BaseDocument {
     private String projectId;
 
     @Indexed(expireAfterSeconds = 6000)
-    private Date createdAt;
+    private Date expiresAt;
 
     public static InviteCode of(String uuid, String projectId){
         return InviteCode.builder()
                 .code(uuid)
                 .projectId(projectId)
+                .expiresAt(new Date())
                 .build();
     }
 }

--- a/src/main/java/com/capstone/domain/project/entity/InviteCode.java
+++ b/src/main/java/com/capstone/domain/project/entity/InviteCode.java
@@ -1,5 +1,6 @@
 package com.capstone.domain.project.entity;
 
+import com.capstone.global.entity.BaseDocument;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,7 +16,7 @@ import java.util.Date;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class InviteCode {
+public class InviteCode extends BaseDocument {
     @Id
     private String id;
     private String code;

--- a/src/main/java/com/capstone/domain/project/entity/InviteCode.java
+++ b/src/main/java/com/capstone/domain/project/entity/InviteCode.java
@@ -22,14 +22,14 @@ public class InviteCode extends BaseDocument {
     private String code;
     private String projectId;
 
-    @Indexed(expireAfterSeconds = 6000)
-    private Date expiresAt;
+    @Indexed(expireAfterSeconds = 0)
+    private Date expireAt;
 
-    public static InviteCode of(String uuid, String projectId){
+    public static InviteCode of(String uuid, String projectId, long ttlSec){
         return InviteCode.builder()
                 .code(uuid)
                 .projectId(projectId)
-                .expiresAt(new Date())
+                .expireAt(new Date(System.currentTimeMillis() + ttlSec * 1000))
                 .build();
     }
 }

--- a/src/main/java/com/capstone/domain/project/entity/InviteCode.java
+++ b/src/main/java/com/capstone/domain/project/entity/InviteCode.java
@@ -1,0 +1,33 @@
+package com.capstone.domain.project.entity;
+
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.Date;
+
+@Document(collection = "invite_code")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InviteCode {
+    @Id
+    private String id;
+    private String code;
+    private String projectId;
+
+    @Indexed(expireAfterSeconds = 6000)
+    private Date createdAt;
+
+    public static InviteCode of(String uuid, String projectId){
+        return InviteCode.builder()
+                .code(uuid)
+                .projectId(projectId)
+                .build();
+    }
+}

--- a/src/main/java/com/capstone/domain/project/entity/InviteCode.java
+++ b/src/main/java/com/capstone/domain/project/entity/InviteCode.java
@@ -23,13 +23,13 @@ public class InviteCode extends BaseDocument {
     private String projectId;
 
     @Indexed(expireAfterSeconds = 0)
-    private Date expireAt;
+    private Date expiresAt;
 
-    public static InviteCode of(String uuid, String projectId, long ttlSec){
+    public static InviteCode of(String uuid, String projectId){
         return InviteCode.builder()
                 .code(uuid)
                 .projectId(projectId)
-                .expireAt(new Date(System.currentTimeMillis() + ttlSec * 1000))
+                .expiresAt(new Date(System.currentTimeMillis() + 600 * 1000))
                 .build();
     }
 }

--- a/src/main/java/com/capstone/domain/project/exception/InvalidInviteCodeException.java
+++ b/src/main/java/com/capstone/domain/project/exception/InvalidInviteCodeException.java
@@ -1,0 +1,10 @@
+package com.capstone.domain.project.exception;
+
+import com.capstone.global.response.exception.GlobalException;
+import com.capstone.global.response.status.ErrorStatus;
+
+public class InvalidInviteCodeException extends GlobalException {
+    public InvalidInviteCodeException() {
+        super(ErrorStatus.CODE_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/capstone/domain/project/repository/InviteCodeRepository.java
+++ b/src/main/java/com/capstone/domain/project/repository/InviteCodeRepository.java
@@ -1,0 +1,10 @@
+package com.capstone.domain.project.repository;
+
+import com.capstone.domain.project.entity.InviteCode;
+import com.capstone.domain.project.repository.custom.CustomInviteCodeRepository;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface InviteCodeRepository extends MongoRepository<InviteCode, String>, CustomInviteCodeRepository {
+}

--- a/src/main/java/com/capstone/domain/project/repository/custom/CustomInviteCodeRepository.java
+++ b/src/main/java/com/capstone/domain/project/repository/custom/CustomInviteCodeRepository.java
@@ -1,0 +1,9 @@
+package com.capstone.domain.project.repository.custom;
+
+import com.capstone.domain.project.entity.InviteCode;
+
+import java.util.Optional;
+
+public interface CustomInviteCodeRepository {
+    Optional<InviteCode> findByCredentialCode(String credentialCode);
+}

--- a/src/main/java/com/capstone/domain/project/repository/custom/CustomInviteCodeRepositoryImpl.java
+++ b/src/main/java/com/capstone/domain/project/repository/custom/CustomInviteCodeRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.capstone.domain.project.repository.custom;
+
+import com.capstone.domain.project.entity.InviteCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+
+@Repository
+@RequiredArgsConstructor
+public class CustomInviteCodeRepositoryImpl implements CustomInviteCodeRepository{
+    private final MongoTemplate mongoTemplate;
+
+    @Override
+    public Optional<InviteCode> findByCredentialCode(String credentialCode) {
+        Query query = new Query(Criteria.where("credentialCode").is(credentialCode));
+        return Optional.ofNullable(mongoTemplate.findOne(query, InviteCode.class));
+    }
+}

--- a/src/main/java/com/capstone/domain/project/repository/custom/CustomInviteCodeRepositoryImpl.java
+++ b/src/main/java/com/capstone/domain/project/repository/custom/CustomInviteCodeRepositoryImpl.java
@@ -18,7 +18,7 @@ public class CustomInviteCodeRepositoryImpl implements CustomInviteCodeRepositor
 
     @Override
     public Optional<InviteCode> findByCredentialCode(String credentialCode) {
-        Query query = new Query(Criteria.where("credentialCode").is(credentialCode));
+        Query query = new Query(Criteria.where("code").is(credentialCode));
         return Optional.ofNullable(mongoTemplate.findOne(query, InviteCode.class));
     }
 }

--- a/src/main/java/com/capstone/domain/project/repository/custom/CustomProjectRepositoryImpl.java
+++ b/src/main/java/com/capstone/domain/project/repository/custom/CustomProjectRepositoryImpl.java
@@ -1,15 +1,15 @@
 package com.capstone.domain.project.repository.custom;
 
-import com.capstone.domain.project.dto.request.ProjectAuthorityRequest;
+
 import com.capstone.domain.project.entity.Project;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.data.mongodb.core.query.Update;
+
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
+
 
 import java.util.*;
 

--- a/src/main/java/com/capstone/domain/user/entity/PendingUser.java
+++ b/src/main/java/com/capstone/domain/user/entity/PendingUser.java
@@ -1,5 +1,6 @@
 package com.capstone.domain.user.entity;
 
+import com.capstone.domain.project.entity.InviteCode;
 import com.capstone.global.entity.BaseDocument;
 import jakarta.persistence.Id;
 import lombok.*;
@@ -12,12 +13,9 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PendingUser extends BaseDocument {
-
     @Id
     private String id;
     private String userId;
-    private String projectId;
-    private String credentialCode;
-
     private String email;
+    private InviteCode inviteCode;
 }

--- a/src/main/java/com/capstone/domain/user/repository/custom/CustomPendingUserRepository.java
+++ b/src/main/java/com/capstone/domain/user/repository/custom/CustomPendingUserRepository.java
@@ -5,6 +5,7 @@ import com.capstone.domain.user.entity.PendingUser;
 import java.util.Optional;
 
 public interface CustomPendingUserRepository {
-    PendingUser findByCredentialCode(String credentialCode);
+    Optional<PendingUser> findByCredentialCode(String credentialCode);
     Optional<PendingUser> findByProjectAndUser(String projectId, String userId);
+    String findProjectByCode(String credentialCode);
 }

--- a/src/main/java/com/capstone/domain/user/repository/custom/CustomPendingUserRepository.java
+++ b/src/main/java/com/capstone/domain/user/repository/custom/CustomPendingUserRepository.java
@@ -6,6 +6,6 @@ import com.capstone.domain.user.entity.PendingUser;
 import java.util.Optional;
 
 public interface CustomPendingUserRepository {
-    Optional<PendingUser> findByCredentialCode(InviteCode credentialCode);
+    Optional<PendingUser> findByCredentialCode(String credentialCode);
     Optional<PendingUser> findByProjectAndUser(String projectId, String userId);
 }

--- a/src/main/java/com/capstone/domain/user/repository/custom/CustomPendingUserRepository.java
+++ b/src/main/java/com/capstone/domain/user/repository/custom/CustomPendingUserRepository.java
@@ -1,10 +1,11 @@
 package com.capstone.domain.user.repository.custom;
 
+import com.capstone.domain.project.entity.InviteCode;
 import com.capstone.domain.user.entity.PendingUser;
 
 import java.util.Optional;
 
 public interface CustomPendingUserRepository {
-    Optional<PendingUser> findByCredentialCode(String credentialCode);
+    Optional<PendingUser> findByCredentialCode(InviteCode credentialCode);
     Optional<PendingUser> findByProjectAndUser(String projectId, String userId);
 }

--- a/src/main/java/com/capstone/domain/user/repository/custom/CustomPendingUserRepository.java
+++ b/src/main/java/com/capstone/domain/user/repository/custom/CustomPendingUserRepository.java
@@ -7,5 +7,4 @@ import java.util.Optional;
 public interface CustomPendingUserRepository {
     Optional<PendingUser> findByCredentialCode(String credentialCode);
     Optional<PendingUser> findByProjectAndUser(String projectId, String userId);
-    String findProjectByCode(String credentialCode);
 }

--- a/src/main/java/com/capstone/domain/user/repository/custom/CustomPendingUserRepositoryImpl.java
+++ b/src/main/java/com/capstone/domain/user/repository/custom/CustomPendingUserRepositoryImpl.java
@@ -19,8 +19,8 @@ public class CustomPendingUserRepositoryImpl implements CustomPendingUserReposit
     private final MongoTemplate mongoTemplate;
 
     @Override
-    public Optional<PendingUser> findByCredentialCode(InviteCode inviteCode) {
-        Query query = new Query().addCriteria(Criteria.where("inviteCode").is(inviteCode));
+    public Optional<PendingUser> findByCredentialCode(String inviteCode) {
+        Query query = new Query().addCriteria(Criteria.where("inviteCode.code").is(inviteCode));
 
         return Optional.ofNullable(mongoTemplate.findOne(query, PendingUser.class));
     }

--- a/src/main/java/com/capstone/domain/user/repository/custom/CustomPendingUserRepositoryImpl.java
+++ b/src/main/java/com/capstone/domain/user/repository/custom/CustomPendingUserRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.capstone.domain.user.repository.custom;
 
+import com.capstone.domain.project.entity.InviteCode;
 import com.capstone.domain.user.entity.PendingUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -18,8 +19,8 @@ public class CustomPendingUserRepositoryImpl implements CustomPendingUserReposit
     private final MongoTemplate mongoTemplate;
 
     @Override
-    public Optional<PendingUser> findByCredentialCode(String credentialCode) {
-        Query query = new Query().addCriteria(Criteria.where("credentialCode").is(credentialCode));
+    public Optional<PendingUser> findByCredentialCode(InviteCode inviteCode) {
+        Query query = new Query().addCriteria(Criteria.where("inviteCode").is(inviteCode));
 
         return Optional.ofNullable(mongoTemplate.findOne(query, PendingUser.class));
     }

--- a/src/main/java/com/capstone/domain/user/repository/custom/CustomPendingUserRepositoryImpl.java
+++ b/src/main/java/com/capstone/domain/user/repository/custom/CustomPendingUserRepositoryImpl.java
@@ -32,12 +32,4 @@ public class CustomPendingUserRepositoryImpl implements CustomPendingUserReposit
         return Optional.ofNullable(mongoTemplate.findOne(query, PendingUser.class));
     }
 
-    @Override
-    public String findProjectByCode(String credentialCode) {
-
-        Query query = new Query().addCriteria(Criteria.where("credentialCode").is(credentialCode));
-        query.fields().include("projectId");
-
-        return mongoTemplate.findOne(query, String.class);
-    }
 }

--- a/src/main/java/com/capstone/domain/user/repository/custom/CustomPendingUserRepositoryImpl.java
+++ b/src/main/java/com/capstone/domain/user/repository/custom/CustomPendingUserRepositoryImpl.java
@@ -18,10 +18,10 @@ public class CustomPendingUserRepositoryImpl implements CustomPendingUserReposit
     private final MongoTemplate mongoTemplate;
 
     @Override
-    public PendingUser findByCredentialCode(String credentialCode) {
+    public Optional<PendingUser> findByCredentialCode(String credentialCode) {
         Query query = new Query().addCriteria(Criteria.where("credentialCode").is(credentialCode));
 
-        return mongoTemplate.findOne(query, PendingUser.class);
+        return Optional.ofNullable(mongoTemplate.findOne(query, PendingUser.class));
     }
 
     @Override
@@ -30,5 +30,14 @@ public class CustomPendingUserRepositoryImpl implements CustomPendingUserReposit
                 .and("userId").is(userId));
 
         return Optional.ofNullable(mongoTemplate.findOne(query, PendingUser.class));
+    }
+
+    @Override
+    public String findProjectByCode(String credentialCode) {
+
+        Query query = new Query().addCriteria(Criteria.where("credentialCode").is(credentialCode));
+        query.fields().include("projectId");
+
+        return mongoTemplate.findOne(query, String.class);
     }
 }

--- a/src/main/java/com/capstone/domain/user/service/ProjectUserService.java
+++ b/src/main/java/com/capstone/domain/user/service/ProjectUserService.java
@@ -71,19 +71,26 @@ public class ProjectUserService {
 
     @Transactional
     public String processInviteAcceptProjectUser(String credentialCode){
-        PendingUser pendingUser = pendingUserRepository.findByCredentialCode(credentialCode);
+        Optional<PendingUser> pendingUserOpt = pendingUserRepository.findByCredentialCode(credentialCode);
+        String projectId = pendingUserRepository.findProjectByCode(credentialCode);
 
-        ProjectUser projectUser = ProjectUser.builder()
-                .projectId(pendingUser.getProjectId())
-                .userId(pendingUser.getEmail())
-                .role("ROLE_MEMBER")
-                .joinedAt(LocalTime.now().toString())
-                .build();
+        if(pendingUserOpt.isEmpty()){
+            return generateRedirectionUri(projectId);
+        }
+        else {
+            PendingUser pendingUser = pendingUserOpt.get();
+            ProjectUser projectUser = ProjectUser.builder()
+                    .projectId(projectId)
+                    .userId(pendingUser.getEmail())
+                    .role("ROLE_MEMBER")
+                    .joinedAt(LocalTime.now().toString())
+                    .build();
 
-        projectUserRepository.save(projectUser);
-        pendingUserRepository.delete(pendingUser);
+            projectUserRepository.save(projectUser);
+            pendingUserRepository.delete(pendingUser);
 
-        return generateRedirectionUri(projectUser.getProjectId());
+            return generateRedirectionUri(projectId);
+        }
     }
 
     private String generateRedirectionUri(String projectId){

--- a/src/main/java/com/capstone/domain/user/service/ProjectUserService.java
+++ b/src/main/java/com/capstone/domain/user/service/ProjectUserService.java
@@ -74,7 +74,6 @@ public class ProjectUserService {
 
     @Transactional
     public String processInviteAcceptProjectUser(String credentialCode){
-        Optional<PendingUser> pendingUserOpt = pendingUserRepository.findByCredentialCode(credentialCode);
         Optional<InviteCode> inviteCodeOpt = inviteCodeRepository.findByCredentialCode(credentialCode);
 
         if(inviteCodeOpt.isEmpty()){
@@ -82,12 +81,9 @@ public class ProjectUserService {
         }
 
         InviteCode inviteCode = inviteCodeOpt.get();
+        Optional<PendingUser> pendingUserOpt = pendingUserRepository.findByCredentialCode(inviteCode);
 
-        if(pendingUserOpt.isEmpty()){
-            return generateRedirectionUri(inviteCode.getProjectId());
-        }
-
-        else {
+        if (pendingUserOpt.isPresent()) {
             PendingUser pendingUser = pendingUserOpt.get();
             ProjectUser projectUser = ProjectUser.builder()
                     .projectId(inviteCode.getProjectId())
@@ -99,8 +95,8 @@ public class ProjectUserService {
             projectUserRepository.save(projectUser);
             pendingUserRepository.delete(pendingUser);
 
-            return generateRedirectionUri(inviteCode.getProjectId());
         }
+        return generateRedirectionUri(inviteCode.getProjectId());
     }
 
     private String generateRedirectionUri(String projectId){

--- a/src/main/java/com/capstone/domain/user/service/ProjectUserService.java
+++ b/src/main/java/com/capstone/domain/user/service/ProjectUserService.java
@@ -81,7 +81,7 @@ public class ProjectUserService {
         }
 
         InviteCode inviteCode = inviteCodeOpt.get();
-        Optional<PendingUser> pendingUserOpt = pendingUserRepository.findByCredentialCode(inviteCode);
+        Optional<PendingUser> pendingUserOpt = pendingUserRepository.findByCredentialCode(inviteCode.getCode());
 
         if (pendingUserOpt.isPresent()) {
             PendingUser pendingUser = pendingUserOpt.get();

--- a/src/main/java/com/capstone/domain/user/service/ProjectUserService.java
+++ b/src/main/java/com/capstone/domain/user/service/ProjectUserService.java
@@ -3,12 +3,14 @@ package com.capstone.domain.user.service;
 import com.capstone.domain.project.dto.request.ProjectAuthorityRequest;
 import com.capstone.domain.project.dto.request.ProjectInviteRequest;
 import com.capstone.domain.project.dto.response.InviteCheckResult;
+import com.capstone.domain.project.entity.InviteCode;
 import com.capstone.domain.project.entity.Project;
+import com.capstone.domain.project.exception.InvalidInviteCodeException;
+import com.capstone.domain.project.repository.InviteCodeRepository;
 import com.capstone.domain.project.repository.ProjectRepository;
 import com.capstone.domain.user.entity.PendingUser;
 import com.capstone.domain.user.entity.ProjectUser;
 import com.capstone.domain.user.entity.User;
-import com.capstone.domain.user.exception.ProjectUserFoundException;
 import com.capstone.domain.user.exception.UserFoundException;
 import com.capstone.domain.user.exception.UserNotFoundException;
 import com.capstone.domain.user.message.UserMessages;
@@ -39,6 +41,7 @@ public class ProjectUserService {
     private final ProjectRepository projectRepository;
     private final PendingUserRepository pendingUserRepository;
     private final UserRepository userRepository;
+    private final InviteCodeRepository inviteCodeRepository;
 
     private final KafkaProducerService kafkaProducerService;
 
@@ -72,15 +75,22 @@ public class ProjectUserService {
     @Transactional
     public String processInviteAcceptProjectUser(String credentialCode){
         Optional<PendingUser> pendingUserOpt = pendingUserRepository.findByCredentialCode(credentialCode);
-        String projectId = pendingUserRepository.findProjectByCode(credentialCode);
+        Optional<InviteCode> inviteCodeOpt = inviteCodeRepository.findByCredentialCode(credentialCode);
+
+        if(inviteCodeOpt.isEmpty()){
+            throw new InvalidInviteCodeException();
+        }
+
+        InviteCode inviteCode = inviteCodeOpt.get();
 
         if(pendingUserOpt.isEmpty()){
-            return generateRedirectionUri(projectId);
+            return generateRedirectionUri(inviteCode.getProjectId());
         }
+
         else {
             PendingUser pendingUser = pendingUserOpt.get();
             ProjectUser projectUser = ProjectUser.builder()
-                    .projectId(projectId)
+                    .projectId(inviteCode.getProjectId())
                     .userId(pendingUser.getEmail())
                     .role("ROLE_MEMBER")
                     .joinedAt(LocalTime.now().toString())
@@ -89,7 +99,7 @@ public class ProjectUserService {
             projectUserRepository.save(projectUser);
             pendingUserRepository.delete(pendingUser);
 
-            return generateRedirectionUri(projectId);
+            return generateRedirectionUri(inviteCode.getProjectId());
         }
     }
 

--- a/src/main/java/com/capstone/domain/user/service/ProjectUserService.java
+++ b/src/main/java/com/capstone/domain/user/service/ProjectUserService.java
@@ -70,8 +70,9 @@ public class ProjectUserService {
     }
 
     @Transactional
-    public void insertProjectUser(String credentialCode){
+    public String processInviteAcceptProjectUser(String credentialCode){
         PendingUser pendingUser = pendingUserRepository.findByCredentialCode(credentialCode);
+
         ProjectUser projectUser = ProjectUser.builder()
                 .projectId(pendingUser.getProjectId())
                 .userId(pendingUser.getEmail())
@@ -82,6 +83,11 @@ public class ProjectUserService {
         projectUserRepository.save(projectUser);
         pendingUserRepository.delete(pendingUser);
 
+        return generateRedirectionUri(projectUser.getProjectId());
+    }
+
+    private String generateRedirectionUri(String projectId){
+        return "https://docktalk.co.kr/project/workboard/" + projectId;
     }
 
 

--- a/src/main/java/com/capstone/global/response/status/ErrorStatus.java
+++ b/src/main/java/com/capstone/global/response/status/ErrorStatus.java
@@ -43,7 +43,10 @@ public enum ErrorStatus implements BaseErrorCode {
     // Task
     TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "TASK_001", "기존에 없던 작업 입니다."),
     VERSION_NOT_FOUND(HttpStatus.NOT_FOUND, "TASK_002", "기존에 없던 버전 입니다."),
-    INVALID_STATUS(HttpStatus.BAD_REQUEST, "TASK_003", "유효하지 않은 작업 상태 값입니다.")
+    INVALID_STATUS(HttpStatus.BAD_REQUEST, "TASK_003", "유효하지 않은 작업 상태 값입니다."),
+
+    //Invite Code
+    CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "INVITE_CODE_001", "이미 만료되었거나 존재하지 않는 초대코드 입니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 어떤 내용을 담고 있는지 한 줄로 요약해주세요. -->
- 프로젝트 초대 로직 수정 및 이동 주소 추가

---

## ✅ 변경사항
<!-- 주요 변경사항을 bullet point로 간단히 작성해주세요. -->
- 이미 초대 수락을 한 사용자가 다시 수락하기를 눌렀을 때 이동만 되고, 트랜잭션은 X
- InviteCode를 별도의 객체로 분리하고 유효기간이 만료되었을 때 예외 처리 추가

---

## 🔍 체크리스트
- [x] PR 제목은 명확한가요?
- [x] 관련 이슈가 있다면 연결했나요?
- [x] 로컬 테스트는 통과했나요?
- [x] 코드에 불필요한 부분은 없나요?

---

## 📎 관련 이슈
<!-- 예: Closes #123 -->
Closes #152

---

## 💬 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보를 적어주세요. 필요 없다면 생략 가능 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 프로젝트 초대를 단일용 초대코드로 전환하고 유효기간 10분을 적용했습니다.
  * 초대 수락 시 고정 주소가 아닌 해당 프로젝트 작업보드로 자동 리디렉션됩니다.
  * 만료되었거나 유효하지 않은 초대코드에 대해 명확한 오류 안내를 제공합니다.

* Chores
  * CI 릴리스 워크플로우 트리거 브랜치를 기능 브랜치로 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->