### PR TITLE
[feat] OAuth 로그인 프록시

### DIFF
--- a/.github/workflows/workflow-release.yml
+++ b/.github/workflows/workflow-release.yml
@@ -2,7 +2,7 @@ name: CI / CD
 
 on:
   push:
-    branches: [feat/#152-invite-redirection-url]
+    branches: [feat/#154-oauth-proxy]
 
 jobs:
   CI:

--- a/.github/workflows/workflow-release.yml
+++ b/.github/workflows/workflow-release.yml
@@ -89,7 +89,7 @@ jobs:
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           source: ".env.production"
           overwrite: true
-          target: "/home/ubuntu/"
+          target: "/home/ubuntu/.env.production"
 
       - name: 서버에 SSH 접속하여 Docker 실행
         uses: appleboy/ssh-action@v0.1.5

--- a/.github/workflows/workflow-release.yml
+++ b/.github/workflows/workflow-release.yml
@@ -83,13 +83,11 @@ jobs:
       - name: 서버에 .env.production 전송
         uses: appleboy/scp-action@v0.1.4
         with:
-          debug: true
           host: ${{ secrets.DEPLOY_SERVER_HOST }}
           username: ${{ secrets.DEPLOY_SERVER_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           source: ".env.production"
-          overwrite: true
-          target: "/home/ubuntu/.env.production"
+          target: "~"
 
       - name: 서버에 SSH 접속하여 Docker 실행
         uses: appleboy/ssh-action@v0.1.5

--- a/.github/workflows/workflow-release.yml
+++ b/.github/workflows/workflow-release.yml
@@ -2,7 +2,7 @@ name: CI / CD
 
 on:
   push:
-    branches: [feat/#154-oauth-proxy]
+    branches: [main]
 
 jobs:
   CI:

--- a/.github/workflows/workflow-release.yml
+++ b/.github/workflows/workflow-release.yml
@@ -87,7 +87,7 @@ jobs:
           username: ${{ secrets.DEPLOY_SERVER_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           source: ".env.production"
-          target: "~"
+          target: "/home/ubuntu/"
 
       - name: 서버에 SSH 접속하여 Docker 실행
         uses: appleboy/ssh-action@v0.1.5

--- a/.github/workflows/workflow-release.yml
+++ b/.github/workflows/workflow-release.yml
@@ -88,6 +88,7 @@ jobs:
           username: ${{ secrets.DEPLOY_SERVER_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           source: ".env.production"
+          overwrite: true
           target: "/home/ubuntu/"
 
       - name: 서버에 SSH 접속하여 Docker 실행

--- a/.github/workflows/workflow-release.yml
+++ b/.github/workflows/workflow-release.yml
@@ -83,6 +83,7 @@ jobs:
       - name: 서버에 .env.production 전송
         uses: appleboy/scp-action@v0.1.4
         with:
+          debug: true
           host: ${{ secrets.DEPLOY_SERVER_HOST }}
           username: ${{ secrets.DEPLOY_SERVER_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}

--- a/.github/workflows/workflow-release.yml
+++ b/.github/workflows/workflow-release.yml
@@ -106,9 +106,9 @@ jobs:
             sudo docker stop $IMAGE_NAME || true
             sudo docker rm $IMAGE_NAME || true
             sudo docker stop zookeeper || true
-            sudo docker rm zookeeper || true
+            sudo docker rm -v zookeeper || true
             sudo docker stop kafka || true
-            sudo docker rm kafka || true
+            sudo docker rm -v kafka || true
 
             sudo docker login --username AWS \
               --password $(aws ecr get-login-password --region $AWS_REGION) \
@@ -130,6 +130,7 @@ jobs:
               -e KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092 \
               -e KAFKA_BROKER_ID=1 \
               -e ALLOW_PLAINTEXT_LISTENER=yes \
+              --tmpfs /bitnami/kafka:rw,size=200m \
               bitnami/kafka:3.3.2
 
             sudo docker run -d \

--- a/src/main/java/com/capstone/domain/AI/config/WebClientConfig.java
+++ b/src/main/java/com/capstone/domain/AI/config/WebClientConfig.java
@@ -18,5 +18,11 @@ public class WebClientConfig {
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .build();
     }
+    @Bean
+    public WebClient oAuth2Client(WebClient.Builder builder) {
+        return builder
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
 }
 

--- a/src/main/java/com/capstone/domain/auth/login/controller/LoginController.java
+++ b/src/main/java/com/capstone/domain/auth/login/controller/LoginController.java
@@ -34,7 +34,7 @@ public class LoginController implements LoginControllerDocs {
             @RequestParam String provider,
             HttpServletResponse response ) throws IOException {
         String redirectUrl = String.format(
-                "https://docktalk.co.kr/oauth2/authorization/%s?mode=login&redirect_uri=https://docktalk.co.kr",
+                "https://docktalk.co.kr/api/oauth2/authorization/%s",
                 provider
         );
         response.sendRedirect(redirectUrl);

--- a/src/main/java/com/capstone/domain/auth/login/controller/LoginController.java
+++ b/src/main/java/com/capstone/domain/auth/login/controller/LoginController.java
@@ -29,12 +29,12 @@ public class LoginController implements LoginControllerDocs {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/oauth/login")
+    @GetMapping("/oauth/login")
     public void redirectToProvider(
             @RequestParam String provider,
             HttpServletResponse response ) throws IOException {
         String redirectUrl = String.format(
-                "https://docktalk.co.kr/oauth2/authorization/%s?ㅇmode=login&redirect_uri=https://docktalk.co.kr",
+                "https://docktalk.co.kr/oauth2/authorization/%s?mode=login&redirect_uri=https://docktalk.co.kr",
                 provider
         );
         response.sendRedirect(redirectUrl);

--- a/src/main/java/com/capstone/domain/auth/login/controller/LoginController.java
+++ b/src/main/java/com/capstone/domain/auth/login/controller/LoginController.java
@@ -2,6 +2,7 @@ package com.capstone.domain.auth.login.controller;
 
 import com.capstone.docs.LoginControllerDocs;
 import com.capstone.domain.auth.login.dto.LoginRequest;
+import com.capstone.domain.oauth2.service.OAuthProxyService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 public class LoginController implements LoginControllerDocs {
+    private final OAuthProxyService oAuthProxyService;
 
     // 로그인 전 해당 경로로 요청을 보내 토큰 획득
 //    @GetMapping("/csrf-token")
@@ -22,5 +24,10 @@ public class LoginController implements LoginControllerDocs {
     @PostMapping("/login")
     public ResponseEntity<String> doLogin(@RequestBody LoginRequest loginRequest){
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/oauth/login")
+    public void oauthLogin(@RequestParam String provider){
+        oAuthProxyService.sendOAuthRequest(provider);
     }
 }

--- a/src/main/java/com/capstone/domain/auth/login/controller/LoginController.java
+++ b/src/main/java/com/capstone/domain/auth/login/controller/LoginController.java
@@ -34,7 +34,7 @@ public class LoginController implements LoginControllerDocs {
             @RequestParam String provider,
             HttpServletResponse response ) throws IOException {
         String redirectUrl = String.format(
-                "https://docktalk.co.kr/oauth2/authorization/%s?access_type=offline&mode=login&redirect_uri=https://docktalk.co.kr",
+                "https://docktalk.co.kr/oauth2/authorization/%s?ㅇmode=login&redirect_uri=https://docktalk.co.kr",
                 provider
         );
         response.sendRedirect(redirectUrl);

--- a/src/main/java/com/capstone/domain/auth/login/controller/LoginController.java
+++ b/src/main/java/com/capstone/domain/auth/login/controller/LoginController.java
@@ -4,10 +4,13 @@ import com.capstone.docs.LoginControllerDocs;
 import com.capstone.domain.auth.login.dto.LoginRequest;
 import com.capstone.domain.oauth2.service.OAuthProxyService;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,7 +30,13 @@ public class LoginController implements LoginControllerDocs {
     }
 
     @PostMapping("/oauth/login")
-    public void oauthLogin(@RequestParam String provider){
-        oAuthProxyService.sendOAuthRequest(provider);
+    public void redirectToProvider(
+            @RequestParam String provider,
+            HttpServletResponse response ) throws IOException {
+        String redirectUrl = String.format(
+                "https://docktalk.co.kr/oauth2/authorization/%s?access_type=offline&mode=login&redirect_uri=https://docktalk.co.kr",
+                provider
+        );
+        response.sendRedirect(redirectUrl);
     }
 }

--- a/src/main/java/com/capstone/domain/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/capstone/domain/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
@@ -54,6 +54,9 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
 
             String googleAccessToken = client.getAccessToken().getTokenValue();
+
+            response.addHeader("access", accessToken);
+            response.addHeader("refresh", refreshToken);
             CookieUtils.addCookie(response, "access_token", accessToken, 3600);
             CookieUtils.addCookie(response, "google_oauth_token", googleAccessToken, 3600);
             CookieUtils.addCookie(response, "refresh_token", refreshToken, 86400);

--- a/src/main/java/com/capstone/domain/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/capstone/domain/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
@@ -74,7 +74,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) {
 
-        String targetUrl = getDefaultTargetUrl();
+        String targetUrl = "https://docktalk.co.kr";
 
         log.info("targetUrl: {}", targetUrl);
 

--- a/src/main/java/com/capstone/domain/oauth2/service/OAuthProxyService.java
+++ b/src/main/java/com/capstone/domain/oauth2/service/OAuthProxyService.java
@@ -11,7 +11,7 @@ public class OAuthProxyService {
     private final WebClient oAuth2Client;
 
     public void sendOAuthRequest(String provider) {
-        oAuth2Client.post()
+        oAuth2Client.get()
                 .uri(uriBuilder -> uriBuilder
                         .scheme("https")
                         .host("docktalk.co.kr")

--- a/src/main/java/com/capstone/domain/oauth2/service/OAuthProxyService.java
+++ b/src/main/java/com/capstone/domain/oauth2/service/OAuthProxyService.java
@@ -1,0 +1,28 @@
+package com.capstone.domain.oauth2.service;
+
+import com.capstone.domain.AI.config.WebClientConfig;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthProxyService {
+    private final WebClient oAuth2Client;
+
+    public void sendOAuthRequest(String provider) {
+        oAuth2Client.post()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .host("docktalk.co.kr")
+                        .path("/oauth2/authorization/{provider}")
+                        .queryParam("access_type", "offline")
+                        .queryParam("mode", "login")
+                        .queryParam("redirect_uri", "https://docktalk.co.kr")
+                        .build(provider)
+                )
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+    }
+}

--- a/src/main/java/com/capstone/global/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/global/config/SecurityConfig.java
@@ -104,7 +104,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(requests -> requests
                         .requestMatchers("/oauth2/**","/register/*","/login", "/swagger-ui/**",    // Swagger UI 관련 경로
                                 "/v3/api-docs/**","/csrf-token", "/project/**", "/socket/**","/document/**", "/editing", "/notification/**",
-                                "/mypage/email/avail","/mypage/password/new","/mypage/email/check", "/project/invite/accept").permitAll()
+                                "/mypage/email/avail","/mypage/password/new","/mypage/email/check", "/project/invite/accept", "/oauth/login").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(configure ->

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,7 +53,7 @@ spring:
             client-secret: ${NAVER_CLIENT_SECRET}
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
-            redirect-uri: "http://localhost:8080/login/oauth2/code/naver"
+            redirect-uri: "https://docktalk.co.kr/login/oauth2/code/naver"
             scope:
               - name
               - email

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,13 +47,13 @@ spring:
               - email
               - https://www.googleapis.com/auth/calendar
               - https://www.googleapis.com/auth/calendar.events
-            redirect-uri: "{baseUrl}/login/oauth2/code/google"
+            redirect-uri: "{baseUrl}/api/login/oauth2/code/google"
           naver:
             client-id: ${NAVER_CLIENT_ID}
             client-secret: ${NAVER_CLIENT_SECRET}
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
-            redirect-uri: "https://docktalk.co.kr/login/oauth2/code/naver"
+            redirect-uri: "https://docktalk.co.kr/api/login/oauth2/code/naver"
             scope:
               - name
               - email
@@ -69,7 +69,7 @@ spring:
             scope: # https://developers.kakao.com/docs/latest/ko/kakaologin/common#user-info
               - profile_nickname
               - profile_image
-            redirect-uri: "{baseUrl}/{action}/oauth2/code/{registrationId}"
+            redirect-uri: "{baseUrl}/api/{action}/oauth2/code/{registrationId}"
             client-name: Kakao
 
         provider:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,7 +53,7 @@ spring:
             client-secret: ${NAVER_CLIENT_SECRET}
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
-            redirect-uri: "https://docktalk.co.kr/login/oauth2/code/naver"
+            redirect-uri: "https://docktalk.co.kr/api/login/oauth2/code/naver"
             scope:
               - name
               - email

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,13 +47,13 @@ spring:
               - email
               - https://www.googleapis.com/auth/calendar
               - https://www.googleapis.com/auth/calendar.events
-            redirect-uri: "{baseUrl}/api/login/oauth2/code/google"
+            redirect-uri: "{baseUrl}/login/oauth2/code/google"
           naver:
             client-id: ${NAVER_CLIENT_ID}
             client-secret: ${NAVER_CLIENT_SECRET}
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
-            redirect-uri: "https://docktalk.co.kr/api/login/oauth2/code/naver"
+            redirect-uri: "https://docktalk.co.kr/login/oauth2/code/naver"
             scope:
               - name
               - email
@@ -69,7 +69,7 @@ spring:
             scope: # https://developers.kakao.com/docs/latest/ko/kakaologin/common#user-info
               - profile_nickname
               - profile_image
-            redirect-uri: "{baseUrl}/api/{action}/oauth2/code/{registrationId}"
+            redirect-uri: "{baseUrl}/{action}/oauth2/code/{registrationId}"
             client-name: Kakao
 
         provider:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -120,6 +120,7 @@ server:
   port: 8080
   address: 0.0.0.0
   max-http-header-size: 16KB
+  forward-headers-strategy: framework
   servlet:
     context-path: /api
   compression:

--- a/src/main/resources/static/oauth2.html
+++ b/src/main/resources/static/oauth2.html
@@ -1,19 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Google OAuth2 Login</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Google OAuth2 Login</title>
 </head>
 <body>
 <h1>Login with Google</h1>
 <p>Click the button below to log in with your Google account:</p>
 
-<!-- GET 요청으로 Google 로그인 페이지로 이동 -->
-<a href="http://localhost:8080/oauth2/authorization/google?access_type=offline&mode=login&redirect_uri=http://gcpassist.com?&userId=999331911900086413&guildId=1343323552555995290">
-  <button type="button" style="padding: 10px 20px; font-size: 16px; cursor: pointer;">
-    Login with Google
-  </button>
+<!-- GET 요청을 DockTalk 서버 프록시로 보냄 -->
+<a href="https://docktalk.co.kr/api/oauth/login?provider=google">
+    <button type="button" style="padding: 10px 20px; font-size: 16px; cursor: pointer;">
+        Login with Google
+    </button>
 </a>
 
 </body>


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 어떤 내용을 담고 있는지 한 줄로 요약해주세요. -->
- Provider별 OAuth 인증 서버로 보내는 게 아닌 백엔드 서버를 경유하도록 추가
---

## ✅ 변경사항
<!-- 주요 변경사항을 bullet point로 간단히 작성해주세요. -->
- 프론트에서 provider 값만 주면 redirectUrl 빌드 후 백에서 요청 전송.

---

## 🔍 체크리스트
- [x] PR 제목은 명확한가요?
- [x] 관련 이슈가 있다면 연결했나요?
- [x] 로컬 테스트는 통과했나요?
- [x] 코드에 불필요한 부분은 없나요?

---

## 📎 관련 이슈
<!-- 예: Closes #123 -->
Closes #154

---

## 💬 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보를 적어주세요. 필요 없다면 생략 가능 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - OAuth 로그인 엔드포인트(/oauth/login) 공개로 공급자 선택 후 DockTalk 도메인으로 안전 리다이렉트.
  - OAuth 로그인 성공 시 액세스/리프레시 토큰을 응답 헤더와 쿠키로 동시 제공.
  - 프로덕션 리다이렉트/콜백 URL 적용으로 docktalk.co.kr 기반 로그인 흐름 일원화.
  - 정적 로그인 페이지의 Google 링크를 프록시 경로로 교체.

- 작업
  - 배포 워크플로우 안정화: 메인 브랜치 트리거 전환, Kafka/ZooKeeper 볼륨 정리 및 임시 파일시스템 마운트 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->